### PR TITLE
Fix navbar menus hiding on mobile view using wrapper

### DIFF
--- a/src/components/wrapper.jsx
+++ b/src/components/wrapper.jsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import styles from './wrapper.module.css';
+
+/**
+ * This is a wrapper component that will be used to wrap the
+ * entire page and provide a consistent layout.
+ *
+ * This component will be prevent the page from being scrolled horizontally.
+ *
+ * @param {object} props The component props.
+ * @param {JSX.Element} props.children The children of the component.
+ * @return {JSX.Element} The wrapper component.
+ */
+export default function Wrapper({children}) {
+  return (
+    <div className={styles.wrapper}>
+      {children}
+    </div>
+  );
+}
+
+Wrapper.propTypes = {
+  children: PropTypes.node,
+};

--- a/src/components/wrapper.module.css
+++ b/src/components/wrapper.module.css
@@ -1,0 +1,6 @@
+.wrapper {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow-x: hidden;
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -7,6 +7,7 @@ import Navbar from '../components/navbar';
 import PageHead from '../components/page-head';
 import Parallax from '../components/parallax';
 import Projects from '../components/projects';
+import Wrapper from '../components/wrapper';
 import projects from '../data/projects.json';
 import translation from '../utils/translation';
 import styles from './index.module.css';
@@ -22,36 +23,38 @@ export default function HomePage() {
   return (
     <>
       <PageHead title={t.get('title')} description={t.get('description')} />
-      <header className='header'>
-        <Navbar />
-      </header>
-      <main>
-        <Parallax />
-        <Container id='about' theme='light-to-dark' large={true}>
-          <h2>{t.get('navMenu1')}</h2>
-          <div className={styles.about}>
-            <div className={styles.photo}>
-              <Image
-                src='/profile-pic.png'
-                width={120}
-                height={120}
-                alt='Fityan picture'
-                className='rounded-picture'
-              />
+      <Wrapper>
+        <header className='header'>
+          <Navbar />
+        </header>
+        <main>
+          <Parallax />
+          <Container id='about' theme='light-to-dark' large={true}>
+            <h2>{t.get('navMenu1')}</h2>
+            <div className={styles.about}>
+              <div className={styles.photo}>
+                <Image
+                  src='/profile-pic.png'
+                  width={120}
+                  height={120}
+                  alt='Fityan picture'
+                  className='rounded-picture'
+                />
+              </div>
+              <p>{t.get('myDescription')}</p>
             </div>
-            <p>{t.get('myDescription')}</p>
-          </div>
-        </Container>
-        <Container id='project' theme='dark' large={true}>
-          <h2>{t.get('navMenu2')}</h2>
-          <Projects projects={projects} />
-        </Container>
-        <Container id='contact' theme='dark-to-light' large={true}>
-          <h2>{t.get('navMenu3')}</h2>
-          <Contacts />
-        </Container>
-      </main>
-      <Footer />
+          </Container>
+          <Container id='project' theme='dark' large={true}>
+            <h2>{t.get('navMenu2')}</h2>
+            <Projects projects={projects} />
+          </Container>
+          <Container id='contact' theme='dark-to-light' large={true}>
+            <h2>{t.get('navMenu3')}</h2>
+            <Contacts />
+          </Container>
+        </main>
+        <Footer />
+      </Wrapper>
     </>
   );
 }

--- a/src/pages/styles.css
+++ b/src/pages/styles.css
@@ -20,7 +20,6 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Quicksand', sans-serif;
-  overflow-x: hidden;
 }
 
 p {


### PR DESCRIPTION
## Changelog
- Create `Wrapper` component and its styling (2a72e943ee40a71a0feaa0c5cfbd60d2319fd483).
- Remove `overflow-x: hidden` from `body` in global styles (3e3f8ade2cb6e6ade2c064dc3355b2fab5a13efe).
- Implement `Wrapper` to home page (3e3f8ade2cb6e6ade2c064dc3355b2fab5a13efe).