### PR TITLE
Fix hydration error: 'project' data not sync with client

### DIFF
--- a/src/components/project.jsx
+++ b/src/components/project.jsx
@@ -31,14 +31,12 @@ import styles from './project.module.css';
 export default function Project({project}) {
   const {locale} = useRouter();
 
-  // Get the project project based on the locale.
-  project.title = project[locale]?.title ?? project.title;
-  project.description = project[locale]?.description ?? project.description;
-
   return (
     <div className={styles.project}>
-      <h3 className={styles.title}>{project.title}</h3>
-      <p>{project.description}</p>
+      <h3 className={styles.title}>
+        {project[locale]?.title ?? project.title}
+      </h3>
+      <p>{project[locale]?.description ?? project.description}</p>
       <div className={styles.buttons}>
         {project.github && (
           <Button


### PR DESCRIPTION
### Description

This error appears when changes the language to Bahasa by adding `/id-ID` in the URL and back to default language.

The cause is the 'project' data in client doesn't match with server-rendered HTML.

### Error screenshot

![image](https://user-images.githubusercontent.com/63894003/214772259-4a78fa04-9db1-4a7c-9e94-6566a52c2c50.png)